### PR TITLE
DEVOPS-354: Use v1 of Firely Azure templates

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,6 +4,7 @@ resources:
       type: github
       name: FirelyTeam/azure-pipeline-templates
       endpoint: FirelyTeam
+      ref: refs/tags/v1
       
 variables:
   buildConfiguration: 'Release'


### PR DESCRIPTION
Use version `v1` (base version) of the Firely Azure templates (FirelyTeam/azure-pipeline-templates).